### PR TITLE
ENH: Expose M-Mode parameter settings

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -13,6 +13,7 @@ See License.txt for details.
 #include "WinProbe.h"
 
 #include <algorithm>
+#include <math.h>
 #include <PlusMath.h>
 
 //----------------------------------------------------------------------------
@@ -59,10 +60,16 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   XML_READ_STRING_ATTRIBUTE_REQUIRED(TransducerID, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(UseDeviceFrameReconstruction, deviceConfig);
   XML_READ_BOOL_ATTRIBUTE_OPTIONAL(SpatialCompoundEnabled, deviceConfig);
+  XML_READ_BOOL_ATTRIBUTE_OPTIONAL(MRevolvingEnabled, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, TransmitFrequencyMHz, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, ScanDepthMm, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(float, SpatialCompoundAngle, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, SpatialCompoundCount, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MPRFrequency, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MLineIndex, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MWidth, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MAcousticLineCount, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MDepth, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, Voltage, deviceConfig); //implicit type conversion
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, MinValue, deviceConfig); //implicit type conversion
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, MaxValue, deviceConfig); //implicit type conversion
@@ -72,6 +79,20 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   if (strMode)
   {
     m_Mode = this->StringToMode(strMode);
+  }
+  if(m_Mode == Mode::M)
+  {
+    const char* mwidthSeconds_string = deviceConfig->GetAttribute("MWidth");
+    std::stringstream mwidthSecondsStream;
+    mwidthSecondsStream << mwidthSeconds_string;
+
+    int mwidthSeconds;
+    mwidthSecondsStream >> mwidthSeconds;
+
+    if (mwidthSeconds)
+    {
+    m_MWidth = this->MWidthFromSeconds(mwidthSeconds);
+    }
   }
 
   deviceConfig->GetVectorAttribute("TimeGainCompensation", 8, m_TimeGainCompensation);
@@ -88,10 +109,16 @@ PlusStatus vtkPlusWinProbeVideoSource::WriteConfiguration(vtkXMLDataElement* roo
   deviceConfig->SetAttribute("TransducerID", this->m_TransducerID.c_str());
   deviceConfig->SetAttribute("UseDeviceFrameReconstruction", this->m_UseDeviceFrameReconstruction ? "TRUE" : "FALSE");
   deviceConfig->SetAttribute("SpatialCompoundEnabled", this->GetSpatialCompoundEnabled() ? "TRUE" : "FALSE");
+  deviceConfig->SetAttribute("MRevolvingEnabled", this->GetMRevolvingEnabled() ? "TRUE" : "FALSE");
   deviceConfig->SetFloatAttribute("TransmitFrequencyMHz", this->GetTransmitFrequencyMHz());
   deviceConfig->SetFloatAttribute("ScanDepthMm", this->GetScanDepthMm());
   deviceConfig->SetFloatAttribute("SpatialCompoundAngle", this->GetSpatialCompoundAngle());
   deviceConfig->SetIntAttribute("SpatialCompoundCount", this->GetSpatialCompoundCount());
+  deviceConfig->SetIntAttribute("MPRFrequency", this->GetMPRFrequency());
+  deviceConfig->SetIntAttribute("MLineIndex", this->GetMLineIndex());
+  deviceConfig->SetIntAttribute("MWidth", this->MSecondsFromWidth(this->m_MWidth));
+  deviceConfig->SetIntAttribute("MAcousticLineCount", this->GetMAcousticLineCount());
+  deviceConfig->SetIntAttribute("MDepth", this->GetMDepth());
   deviceConfig->SetUnsignedLongAttribute("Voltage", this->GetVoltage());
   deviceConfig->SetUnsignedLongAttribute("MinValue", this->GetMinValue());
   deviceConfig->SetUnsignedLongAttribute("MaxValue", this->GetMaxValue());
@@ -163,6 +190,47 @@ std::string vtkPlusWinProbeVideoSource::ModeToString(vtkPlusWinProbeVideoSource:
     return "B";
     break;
   }
+}
+
+// ----------------------------------------------------------------------------
+int32_t vtkPlusWinProbeVideoSource::MWidthFromSeconds(int value)
+{
+  int32_t mlineWidth;
+  if(value < 4)
+  {
+    mlineWidth = 128 * pow(2, value - 1);
+  }
+  else if(value <= 80)
+  {
+    mlineWidth = 1024 * value / 10;
+  }
+  else
+  {
+    mlineWidth = 128;  //Default to 1s width
+  }
+  return mlineWidth;
+}
+
+int vtkPlusWinProbeVideoSource::MSecondsFromWidth(int32_t value)
+{
+  int mwidthSeconds;
+  if(value < 1024)
+  {
+    mwidthSeconds = std::log(value/128) / std::log(2) + 1;
+  }
+  else if(value <= 8192)
+  {
+    mwidthSeconds = value * 10 / 1024;
+    if(mwidthSeconds == 8)
+    {
+      mwidthSeconds += 1;  //81 s
+    }
+  }
+  else
+  {
+    mwidthSeconds = 1;  //Default to 1s width
+  }
+  return mwidthSeconds;
 }
 
 // ----------------------------------------------------------------------------
@@ -571,7 +639,14 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   if(m_Mode == Mode::M)
   {
-    SetMIsEnabled(true);
+    LOG_INFO("M-Mode enabled");
+    this->SetMModeEnabled(true);
+    this->SetMRevolvingEnabled(m_MRevolvingEnabled);
+    this->SetMPRFrequency(m_MPRF);
+    this->SetMLineIndex(m_MLineIndex);
+    ::SetMWidth(m_MWidth);
+    SetPendingRecreateTables(true);
+    this->SetMAcousticLineCount(m_MAcousticLineCount);
   }
 
   m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime();
@@ -842,6 +917,170 @@ int32_t vtkPlusWinProbeVideoSource::GetSpatialCompoundCount()
     m_SpatialCompoundCount = GetSCCompoundAngleCount();
   }
   return m_SpatialCompoundCount;
+}
+
+//----------------------------------------------------------------------------
+
+void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
+{
+
+  // m_MModeEnabled = value;
+  if(Connected)
+  {
+    SetMIsEnabled(value);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+  }
+  if(value)
+  {
+    m_Mode = Mode::M;
+  }
+  else
+  {
+    m_Mode = Mode::B;
+  }
+}
+
+bool vtkPlusWinProbeVideoSource::GetMModeEnabled()
+{
+  bool mmodeEnabled;
+  if(Connected)
+  {
+    mmodeEnabled = GetMIsEnabled();
+    if(mmodeEnabled)
+    {
+      m_Mode = Mode::M;
+    }
+    else
+    {
+      m_Mode = Mode::B;
+    }
+  }
+  return mmodeEnabled;
+}
+
+
+void vtkPlusWinProbeVideoSource::SetMRevolvingEnabled(bool value)
+{
+  if(Connected)
+  {
+    SetMIsRevolving(value);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+  }
+   m_MRevolvingEnabled = value;
+}
+
+bool vtkPlusWinProbeVideoSource::GetMRevolvingEnabled()
+{
+  if(Connected)
+  {
+    m_MRevolvingEnabled = GetMIsRevolving();
+  }
+  return m_MRevolvingEnabled;
+}
+
+void vtkPlusWinProbeVideoSource::SetMPRFrequency(int32_t value)
+{
+  if(Connected)
+  {
+    SetMPRF(value);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+  }
+  m_MPRF = value;
+}
+
+int32_t vtkPlusWinProbeVideoSource::GetMPRFrequency()
+{
+  if(Connected)
+  {
+    m_MPRF = GetMPRF();
+  }
+  return m_MPRF;
+}
+
+void vtkPlusWinProbeVideoSource::SetMLineIndex(int32_t value)
+{
+  if(Connected)
+  {
+    SetMAcousticLineIndex(value);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+  }
+  m_MLineIndex = value;
+}
+
+int32_t vtkPlusWinProbeVideoSource::GetMLineIndex()
+{
+  if(Connected)
+  {
+    m_MLineIndex = GetMAcousticLineIndex();
+  }
+  return m_MLineIndex;
+}
+
+void vtkPlusWinProbeVideoSource::SetMWidth(int value)
+{
+  if(Connected)
+  {
+    int32_t mwidth = this->MWidthFromSeconds(value);
+    ::SetMWidth(mwidth);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+  }
+  m_MWidth = value;
+}
+
+int32_t vtkPlusWinProbeVideoSource::GetMWidth()
+{
+  int mwidthSeconds = 0;
+  if(Connected)
+  {
+    m_MWidth = ::GetMWidth();
+    mwidthSeconds = this->MSecondsFromWidth(m_MWidth);
+  }
+  return mwidthSeconds;
+}
+
+void vtkPlusWinProbeVideoSource::SetMAcousticLineCount(int32_t value)
+{
+  if(Connected)
+  {
+    ::SetMAcousticLineCount(value);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+  }
+  m_MAcousticLineCount = value;
+}
+
+int32_t vtkPlusWinProbeVideoSource::GetMAcousticLineCount()
+{
+  if(Connected)
+  {
+    m_MAcousticLineCount = ::GetMAcousticLineCount();
+  }
+  return m_MAcousticLineCount;
+}
+
+void vtkPlusWinProbeVideoSource::SetMDepth(int32_t value)
+{
+  if(Connected)
+  {
+    ::SetMDepth(value);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+  }
+  m_MDepth = value;
+}
+
+int32_t vtkPlusWinProbeVideoSource::GetMDepth()
+{
+  if(Connected)
+  {
+    m_MDepth = ::GetMDepth();
+  }
+  return m_MDepth;
 }
 
 //----------------------------------------------------------------------------

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -13,7 +13,7 @@ See License.txt for details.
 #include "WinProbe.h"
 
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 #include <PlusMath.h>
 
 //----------------------------------------------------------------------------
@@ -83,12 +83,7 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   if(m_Mode == Mode::M)
   {
     const char* mwidthSeconds_string = deviceConfig->GetAttribute("MWidth");
-    std::stringstream mwidthSecondsStream;
-    mwidthSecondsStream << mwidthSeconds_string;
-
-    int mwidthSeconds;
-    mwidthSecondsStream >> mwidthSeconds;
-
+    int mwidthSeconds = std::stoi(mwidthSeconds_string);
     if (mwidthSeconds)
     {
     m_MWidth = this->MWidthFromSeconds(mwidthSeconds);
@@ -221,7 +216,7 @@ int vtkPlusWinProbeVideoSource::MSecondsFromWidth(int32_t value)
   else if(value <= 8192)
   {
     mwidthSeconds = value * 10 / 1024;
-    if(mwidthSeconds == 8)
+    if(mwidthSeconds == 80)
     {
       mwidthSeconds += 1;  //81 s
     }

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -636,12 +636,6 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
   {
     LOG_INFO("M-Mode enabled");
     this->SetMModeEnabled(true);
-    this->SetMRevolvingEnabled(m_MRevolvingEnabled);
-    this->SetMPRFrequency(m_MPRF);
-    this->SetMLineIndex(m_MLineIndex);
-    ::SetMWidth(m_MWidth);
-    SetPendingRecreateTables(true);
-    this->SetMAcousticLineCount(m_MAcousticLineCount);
   }
 
   m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime();
@@ -923,6 +917,14 @@ void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
   if(Connected)
   {
     SetMIsEnabled(value);
+    if(value)
+    {
+      SetMIsRevolving(m_MRevolvingEnabled);
+      SetMPRF(m_MPRF);
+      SetMAcousticLineIndex(m_MLineIndex);
+      ::SetMWidth(m_MWidth);
+      ::SetMAcousticLineCount(m_MAcousticLineCount);
+    }
     SetPendingRecreateTables(true);
     m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -126,6 +126,27 @@ public:
   void SetSpatialCompoundCount(int32_t value);
   int32_t GetSpatialCompoundCount();
 
+  void SetMModeEnabled(bool value);
+  bool GetMModeEnabled();
+
+  void SetMRevolvingEnabled(bool value);
+  bool GetMRevolvingEnabled();
+
+  void SetMPRFrequency(int32_t value);
+  int32_t GetMPRFrequency();
+
+  void SetMLineIndex(int32_t value);
+  int32_t GetMLineIndex();
+
+  void SetMWidth(int value);
+  int GetMWidth();
+
+  void SetMAcousticLineCount(int32_t value);
+  int32_t GetMAcousticLineCount();
+
+  void SetMDepth(int32_t value);
+  int32_t GetMDepth();
+
   enum class Mode
   {
     B = 0, // only B mode
@@ -150,6 +171,9 @@ public:
 
   Mode StringToMode(std::string modeString);
   std::string ModeToString(Mode mode);
+
+  int32_t MWidthFromSeconds(int value);
+  int MSecondsFromWidth(int32_t value);
 
 protected:
   /*! Constructor */
@@ -201,6 +225,12 @@ protected:
   bool m_SpatialCompoundEnabled = false;
   float m_SpatialCompoundAngle = 10.0f;
   int32_t m_SpatialCompoundCount = 0;
+  bool m_MRevolvingEnabled = false;
+  int32_t m_MPRF = 100;
+  int32_t m_MLineIndex = 60;
+  int32_t m_MWidth = 256;
+  int32_t m_MAcousticLineCount = 0;
+  int32_t m_MDepth = 0;
   std::vector<vtkPlusDataSource*> m_PrimarySources;
   std::vector<vtkPlusDataSource*> m_ExtraSources;
 


### PR DESCRIPTION
Exposes settings for M-Mode:

- MModeEnabled
- MRevolvingEnabled
- MPRFrequency
- MLineIndex
- MWidth (default XML shows range of 64-8192 which corresponds to time axis total duration displayed 0s to 81s according to UltraVision App, so I've included conversion factor for this)
- MAcousticLineCount

