### PR TITLE
BUG: Copy all WinProbe DLLs on build

### DIFF
--- a/src/PlusDataCollection/CMakeLists.txt
+++ b/src/PlusDataCollection/CMakeLists.txt
@@ -1495,6 +1495,7 @@ IF(PLUS_USE_WINPROBE_VIDEO)
   ENDIF()
 
   FILE(GLOB WinProbeAssemblies "${WINPROBESDK_DIR}/${Bitness}/*.dll")
+  FILE(COPY ${WinProbeAssemblies} DESTINATION ${CMAKE_BINARY_DIR})
 
   LIST(APPEND ${PROJECT_NAME}_LIBS
     ${WINPROBESDK_DIR}/${Bitness}/$<$<CONFIG:Debug>:Debug>$<$<NOT:$<CONFIG:Debug>>:Release>/UltraVisionManagedDll${CMAKE_STATIC_LIBRARY_SUFFIX}


### PR DESCRIPTION
Copy all WinProbe DLLs to PlusBuildDirectory/bin/Release, to enable successful WP live stream with `UseDeviceFrameReconstruction="True"`, on running PlusServer.exe 