### PR TITLE
ENH: Expose set/get SSDecimation

### DIFF
--- a/src/PlusDataCollection/CMakeLists.txt
+++ b/src/PlusDataCollection/CMakeLists.txt
@@ -1576,6 +1576,7 @@ IF(PLUS_USE_WINPROBE_VIDEO)
   ENDIF()
 
   FILE(GLOB WinProbeAssemblies "${WINPROBESDK_DIR}/${Bitness}/*.dll")
+  FILE(COPY ${WinProbeAssemblies} DESTINATION ${CMAKE_BINARY_DIR})
 
   LIST(APPEND ${PROJECT_NAME}_LIBS
     ${WINPROBESDK_DIR}/${Bitness}/$<$<CONFIG:Debug>:Debug>$<$<NOT:$<CONFIG:Debug>>:Release>/UltraVisionManagedDll${CMAKE_STATIC_LIBRARY_SUFFIX}

--- a/src/PlusDataCollection/Testing/vtkWinProbeVideoSourceTest.cxx
+++ b/src/PlusDataCollection/Testing/vtkWinProbeVideoSourceTest.cxx
@@ -172,7 +172,7 @@ int main(int argc, char* argv[])
     viewer->SetColorWindow(255);
     viewer->SetColorLevel(127.5);
     viewer->SetZSlice(0);
-    viewer->SetSize(512, 1024);
+    viewer->SetSize(256, 640);
 
     //Create the interactor that handles the event loop
     vtkSmartPointer<vtkRenderWindowInteractor> iren = vtkSmartPointer<vtkRenderWindowInteractor>::New();

--- a/src/PlusDataCollection/Testing/vtkWinProbeVideoSourceTest.cxx
+++ b/src/PlusDataCollection/Testing/vtkWinProbeVideoSourceTest.cxx
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
 
 
   vtkSmartPointer< vtkPlusWinProbeVideoSource > WinProbeDevice = vtkSmartPointer< vtkPlusWinProbeVideoSource >::New();
-  WinProbeDevice->SetDeviceId("VideoDevice");
+  WinProbeDevice->SetDeviceId("VideoDeviceWP");
 
   vtkSmartPointer<vtkXMLDataElement> configRootElement = vtkSmartPointer<vtkXMLDataElement>::New();
   if(STRCASECMP(inputConfigFileName.c_str(), "") != 0)
@@ -168,7 +168,7 @@ int main(int argc, char* argv[])
   else
   {
     vtkSmartPointer<vtkImageViewer> viewer = vtkSmartPointer<vtkImageViewer>::New();
-    viewer->SetInputConnection(WinProbeDevice->GetOutputPort()); //set image to the render and window
+    viewer->SetInputConnection(WinProbeDevice->GetOutputPort(0)); //set image to the render and window
     viewer->SetColorWindow(255);
     viewer->SetColorLevel(127.5);
     viewer->SetZSlice(0);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -505,10 +505,6 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
   {
     SetPWIsEnabled(true);
   }
-  if(m_Mode == Mode::M)
-  {
-    SetMIsEnabled(true);
-  }
   if(m_Mode == Mode::CFD)
   {
     SetVoltage(70);
@@ -573,6 +569,10 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
   WPDXSetDrawTextLayer(false);
   WPDXSetDrawScalesAndBars(false);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  if(m_Mode == Mode::M)
+  {
+    SetMIsEnabled(true);
+  }
 
   m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime();
   LOG_DEBUG("GetPendingRecreateTables: " << GetPendingRecreateTables());

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -970,8 +970,6 @@ int32_t vtkPlusWinProbeVideoSource::GetSpatialCompoundCount()
 
 void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
 {
-
-  // m_MModeEnabled = value;
   if(Connected)
   {
     SetMIsEnabled(value);
@@ -998,7 +996,7 @@ void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
 
 bool vtkPlusWinProbeVideoSource::GetMModeEnabled()
 {
-  bool mmodeEnabled;
+  bool mmodeEnabled = (m_Mode == Mode::M);
   if(Connected)
   {
     mmodeEnabled = GetMIsEnabled();

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -450,11 +450,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
   this->SetTransmitFrequencyMHz(m_Frequency);
   this->SetVoltage(m_Voltage);
   this->SetScanDepthMm(m_ScanDepth); //as a side-effect calls AdjustSpacing and AdjustBufferSize
-  if (m_SpatialCompoundEnabled)
-  {
-    this->SetSpatialCompoundAngle(m_SpatialCompoundAngle);
-    this->SetSpatialCompoundCount(m_SpatialCompoundCount);
-  }
+  this->SetSpatialCompoundEnabled(m_SpatialCompoundEnabled); // also takes care of angle  and count
 
   //setup size for DirectX image
   LOG_DEBUG("Setting output size to " << m_LineCount << "x" << m_SamplesPerLine);
@@ -675,6 +671,15 @@ void vtkPlusWinProbeVideoSource::SetSpatialCompoundEnabled(bool value)
   if(Connected)
   {
     SetSCIsEnabled(value);
+    if (value)
+    {
+      SetSCCompoundAngle(m_SpatialCompoundAngle);
+      SetSCCompoundAngleCount(m_SpatialCompoundCount);
+    }
+    else
+    {
+      SetSCCompoundAngleCount(0);
+    }
     SetPendingRecreateTables(true);
     m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -68,6 +68,7 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MPRFrequency, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MLineIndex, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MWidth, deviceConfig);
+  XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int32_t, MWidthLines, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MAcousticLineCount, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(int, MDepth, deviceConfig);
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, Voltage, deviceConfig); //implicit type conversion
@@ -115,6 +116,7 @@ PlusStatus vtkPlusWinProbeVideoSource::WriteConfiguration(vtkXMLDataElement* roo
   deviceConfig->SetIntAttribute("MPRFrequency", this->GetMPRFrequency());
   deviceConfig->SetIntAttribute("MLineIndex", this->GetMLineIndex());
   deviceConfig->SetIntAttribute("MWidth", this->MSecondsFromWidth(this->m_MWidth));
+  deviceConfig->SetIntAttribute("MWidthLines", this->m_MWidth);
   deviceConfig->SetIntAttribute("MAcousticLineCount", this->GetMAcousticLineCount());
   deviceConfig->SetIntAttribute("MDepth", this->GetMDepth());
   deviceConfig->SetUnsignedLongAttribute("Voltage", this->GetVoltage());
@@ -1077,11 +1079,11 @@ void vtkPlusWinProbeVideoSource::SetMWidth(int value)
     int32_t mwidth = this->MWidthFromSeconds(value);
     ::SetMWidth(mwidth);
     SetPendingRecreateTables(true);
+    m_MWidth = mwidth;
   }
-  m_MWidth = value;
 }
 
-int32_t vtkPlusWinProbeVideoSource::GetMWidth()
+int vtkPlusWinProbeVideoSource::GetMWidth()
 {
   int mwidthSeconds = 0;
   if(Connected)
@@ -1090,6 +1092,25 @@ int32_t vtkPlusWinProbeVideoSource::GetMWidth()
     mwidthSeconds = this->MSecondsFromWidth(m_MWidth);
   }
   return mwidthSeconds;
+}
+
+void vtkPlusWinProbeVideoSource::SetMWidthLines(int32_t value)
+{
+  if(Connected)
+  {
+    ::SetMWidth(value);
+    SetPendingRecreateTables(true);
+  }
+  m_MWidth = value;
+}
+
+int32_t vtkPlusWinProbeVideoSource::GetMWidthLines()
+{
+  if(Connected)
+  {
+    m_MWidth = ::GetMWidth();
+  }
+  return m_MWidth;
 }
 
 void vtkPlusWinProbeVideoSource::SetMAcousticLineCount(int32_t value)

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -76,17 +76,20 @@ PlusStatus vtkPlusWinProbeVideoSource::ReadConfiguration(vtkXMLDataElement* root
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, LogLinearKnee, deviceConfig); //implicit type conversion
   XML_READ_SCALAR_ATTRIBUTE_OPTIONAL(unsigned long, LogMax, deviceConfig); //implicit type conversion
   const char* strMode = deviceConfig->GetAttribute("Mode");
-  if (strMode)
+  if(strMode)
   {
     m_Mode = this->StringToMode(strMode);
   }
   if(m_Mode == Mode::M)
   {
     const char* mwidthSeconds_string = deviceConfig->GetAttribute("MWidth");
-    int mwidthSeconds = std::stoi(mwidthSeconds_string);
-    if (mwidthSeconds)
+    if(mwidthSeconds_string)
     {
-    m_MWidth = this->MWidthFromSeconds(mwidthSeconds);
+      int mwidthSeconds = std::stoi(mwidthSeconds_string);
+      if(mwidthSeconds > 0)
+      {
+        m_MWidth = this->MWidthFromSeconds(mwidthSeconds);
+      }
     }
   }
 
@@ -211,7 +214,7 @@ int vtkPlusWinProbeVideoSource::MSecondsFromWidth(int32_t value)
   int mwidthSeconds;
   if(value < 1024)
   {
-    mwidthSeconds = std::log(value/128) / std::log(2) + 1;
+    mwidthSeconds = std::log(value / 128) / std::log(2) + 1;
   }
   else if(value <= 8192)
   {
@@ -315,7 +318,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
 
   //timestamp counters are in milliseconds since last recreate tables call
   double timestamp = header->TimeStamp / 1000.0;
-  if (timestamp == 0.0) // some change is being applied, so this frame is not valid
+  if(timestamp == 0.0) // some change is being applied, so this frame is not valid
   {
     return; // ignore this frame
   }
@@ -526,7 +529,7 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
 
   std::string presetPath = "Default.xml";
   LOG_DEBUG("Loading Default Presets. " << presetPath);
-  if (!LoadXmlPreset(presetPath.c_str()))
+  if(!LoadXmlPreset(presetPath.c_str()))
   {
     LOG_ERROR("Failed loading default presets!")
     return PLUS_FAIL;
@@ -634,7 +637,6 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   if(m_Mode == Mode::M)
   {
-    LOG_INFO("M-Mode enabled");
     this->SetMModeEnabled(true);
   }
 
@@ -736,7 +738,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetScanDepthMm(float depth)
   m_ScanDepth = depth;
   if(Connected)
   {
-    if (Recording)
+    if(Recording)
     {
       WPStopScanning();
     }
@@ -748,9 +750,9 @@ PlusStatus vtkPlusWinProbeVideoSource::SetScanDepthMm(float depth)
     AdjustSpacing();
     AdjustBufferSize();
     m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
-    if (Recording)
+    if(Recording)
     {
-       WPExecute();
+      WPExecute();
     }
   }
   return PLUS_SUCCESS;
@@ -842,7 +844,7 @@ void vtkPlusWinProbeVideoSource::SetSpatialCompoundEnabled(bool value)
   if(Connected)
   {
     SetSCIsEnabled(value);
-    if (value)
+    if(value)
     {
       SetSCCompoundAngle(m_SpatialCompoundAngle);
       SetSCCompoundAngleCount(m_SpatialCompoundCount);
@@ -926,6 +928,7 @@ void vtkPlusWinProbeVideoSource::SetMModeEnabled(bool value)
     }
     SetPendingRecreateTables(true);
     m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+    LOG_INFO("M-Mode enabled");
   }
   if(value)
   {
@@ -964,7 +967,7 @@ void vtkPlusWinProbeVideoSource::SetMRevolvingEnabled(bool value)
     SetPendingRecreateTables(true);
     m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }
-   m_MRevolvingEnabled = value;
+  m_MRevolvingEnabled = value;
 }
 
 bool vtkPlusWinProbeVideoSource::GetMRevolvingEnabled()

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -173,8 +173,12 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
     return;
   }
 
-  //timestamp counters are in milliseconds since last execute() call
+  //timestamp counters are in milliseconds since last recreate tables call
   double timestamp = header->TimeStamp / 1000.0;
+  if (timestamp == 0.0) // some change is being applied, so this frame is not valid
+  {
+    return; // ignore this frame
+  }
   timestamp += m_TimestampOffset;
   LOG_DEBUG("Frame: " << FrameNumber << ". Mode: " << std::setw(4) << std::hex << usMode << ". Timestamp: " << timestamp);
 
@@ -185,7 +189,7 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
 
     if(m_UseDeviceFrameReconstruction && usMode == B) //this only works with plain B-mode
     {
-      WPNewData(length, data, hHeader, hGeometry);
+      //WPNewData(length, data, hHeader, hGeometry);
       char* frameData = nullptr;
       int length = WPSaveImageToPointer(&frameData);
       assert(length == m_LineCount * m_SamplesPerLine * sizeof(uint32_t));
@@ -264,6 +268,7 @@ void vtkPlusWinProbeVideoSource::AdjustBufferSize()
   LOG_DEBUG("Set up image buffers for WinProbe");
   for(unsigned i = 0; i < m_BSources.size(); i++)
   {
+    m_BSources[i]->Clear(); // clear current buffer content
     m_BSources[i]->SetPixelType(VTK_UNSIGNED_CHAR);
     m_BSources[i]->SetImageType(US_IMG_BRIGHTNESS);
     m_BSources[i]->SetOutputImageOrientation(US_IMG_ORIENT_MF);
@@ -280,6 +285,7 @@ void vtkPlusWinProbeVideoSource::AdjustBufferSize()
   {
     frameSize[0] = m_SamplesPerLine*::GetSSDecimation();
     frameSize[1] = m_LineCount;
+    m_RFSources[i]->Clear(); // clear current buffer content
     m_RFSources[i]->SetPixelType(VTK_INT);
     m_RFSources[i]->SetImageType(US_IMG_RF_REAL);
     m_RFSources[i]->SetOutputImageOrientation(US_IMG_ORIENT_FM);
@@ -452,7 +458,6 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
 
   //setup size for DirectX image
   LOG_DEBUG("Setting output size to " << m_LineCount << "x" << m_SamplesPerLine);
-  WPSetSize(m_LineCount, m_SamplesPerLine);
   char* sessionPtr = GetSessionPtr();
   bool success = WPVPSetSession(sessionPtr);
   if(!success)
@@ -461,6 +466,9 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalStartRecording()
     WPDisconnect();
     return PLUS_FAIL;
   }
+  WPSetSize(m_LineCount, m_SamplesPerLine);
+  WPDXSetDrawTextLayer(false);
+  WPDXSetDrawScalesAndBars(false);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime();
@@ -512,8 +520,10 @@ PlusStatus vtkPlusWinProbeVideoSource::SetTransmitFrequencyMHz(float frequency)
   {
     ::SetTxTxFrequency(frequency);
     SetPendingRecreateTables(true);
+
     //what we requested might be only approximately satisfied
     m_Frequency = ::GetTxTxFrequency();
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }
   return PLUS_SUCCESS;
 }
@@ -538,6 +548,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetVoltage(uint8_t voltage)
     SetPendingRecreateTables(true);
     //what we requested might be only approximately satisfied
     m_Voltage = ::GetVoltage();
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }
   return PLUS_SUCCESS;
 }
@@ -558,6 +569,10 @@ PlusStatus vtkPlusWinProbeVideoSource::SetScanDepthMm(float depth)
   m_ScanDepth = depth;
   if(Connected)
   {
+    if (Recording)
+    {
+      WPStopScanning();
+    }
     ::SetSSDepth(depth);
     SetPendingRecreateTables(true);
     //what we requested might be only approximately satisfied
@@ -565,6 +580,11 @@ PlusStatus vtkPlusWinProbeVideoSource::SetScanDepthMm(float depth)
     m_SamplesPerLine = static_cast<unsigned int>(GetSSSamplesPerLine()); //this and decimation change depending on depth
     AdjustSpacing();
     AdjustBufferSize();
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
+    if (Recording)
+    {
+       WPExecute();
+    }
   }
   return PLUS_SUCCESS;
 }
@@ -614,8 +634,8 @@ PlusStatus vtkPlusWinProbeVideoSource::SetTimeGainCompensation(int index, double
   if(Connected)
   {
     SetTGC(index, value);
-    SetPendingRecreateTables(true);
-    //SetPendingTGCUpdate(true);
+    //SetPendingRecreateTables(true);
+    SetPendingTGCUpdate(true);
     //what we requested might be only approximately satisfied
     m_TimeGainCompensation[index] = GetTGC(index);
   }
@@ -644,6 +664,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetFocalPointDepth(int index, float depth
     SetPendingRecreateTables(true);
     //what we requested might be only approximately satisfied
     m_FocalPointDepth[index] = ::GetFocalPointDepth(index);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }
   return PLUS_SUCCESS;
 }
@@ -654,6 +675,8 @@ void vtkPlusWinProbeVideoSource::SetSpatialCompoundEnabled(bool value)
   if(Connected)
   {
     SetSCIsEnabled(value);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }
   m_SpatialCompoundEnabled = value;
 }
@@ -673,7 +696,9 @@ void vtkPlusWinProbeVideoSource::SetSpatialCompoundAngle(float value)
   if(Connected)
   {
     SetSCCompoundAngle(value);
+    SetPendingRecreateTables(true);
     m_SpatialCompoundAngle = GetSCCompoundAngle(); //in case it was not exactly satisfied
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }
 }
 
@@ -691,6 +716,8 @@ void vtkPlusWinProbeVideoSource::SetSpatialCompoundCount(int32_t value)
   if(Connected)
   {
     SetSCCompoundAngleCount(value);
+    SetPendingRecreateTables(true);
+    m_TimestampOffset = vtkIGSIOAccurateTimer::GetSystemTime(); // recreate tables resets internal timer
   }
   m_SpatialCompoundCount = value;
 }

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -474,6 +474,36 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
     SetHandleBRFInternally(false);
     SetBFRFImageCaptureMode(2);
   }
+  if(m_Mode != Mode::RF) // all modes except pure RF require primary source
+  {
+    if(m_BSources.empty())
+    {
+      LOG_ERROR("Primary source is not defined!");
+    }
+  }
+  if(m_Mode == Mode::RF || m_Mode == Mode::BRF)
+  {
+    if(m_RFSources.empty())
+    {
+      LOG_ERROR("RF source is not defined!");
+    }
+  }
+  if(m_Mode == Mode::PW)
+  {
+    SetPWIsEnabled(true);
+  }
+  if(m_Mode == Mode::M)
+  {
+    SetMIsEnabled(true);
+  }
+  if(m_Mode == Mode::CFD)
+  {
+    SetVoltage(70);
+    SetCFSamplesPerKernel(2);
+    // ...
+    // more setup required
+    SetCFIsEnabled(true);
+  }
   //TODO handle additional modes
 
   LOG_DEBUG("GetHandleBRFInternally: " << GetHandleBRFInternally());

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -193,41 +193,13 @@ std::string vtkPlusWinProbeVideoSource::ModeToString(vtkPlusWinProbeVideoSource:
 // ----------------------------------------------------------------------------
 int32_t vtkPlusWinProbeVideoSource::MWidthFromSeconds(int value)
 {
-  int32_t mlineWidth;
-  if(value < 4)
-  {
-    mlineWidth = 128 * pow(2, value - 1);
-  }
-  else if(value <= 80)
-  {
-    mlineWidth = 1024 * value / 10;
-  }
-  else
-  {
-    mlineWidth = 128;  //Default to 1s width
-  }
+  int32_t mlineWidth = pow(2, round(std::log(value * m_MPRF) / std::log(2)));
   return mlineWidth;
 }
 
 int vtkPlusWinProbeVideoSource::MSecondsFromWidth(int32_t value)
 {
-  int mwidthSeconds;
-  if(value < 1024)
-  {
-    mwidthSeconds = std::log(value / 128) / std::log(2) + 1;
-  }
-  else if(value <= 8192)
-  {
-    mwidthSeconds = value * 10 / 1024;
-    if(mwidthSeconds == 80)
-    {
-      mwidthSeconds += 1;  //81 s
-    }
-  }
-  else
-  {
-    mwidthSeconds = 1;  //Default to 1s width
-  }
+  int mwidthSeconds = floor(value / m_MPRF);
   return mwidthSeconds;
 }
 

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -210,7 +210,7 @@ vtkPlusWinProbeVideoSource* thisPtr = nullptr;
 
 //-----------------------------------------------------------------------------
 // This callback function is invoked after each frame is ready
-int __stdcall frameCallback(int length, char* data, char* hHeader, char* hGeometry)
+int __stdcall frameCallback(int length, char* data, char* hHeader, char* hGeometry, char* hModeFrameHeader)
 {
   thisPtr->FrameCallback(length, data, hHeader, hGeometry);
   return length;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -643,7 +643,7 @@ PlusStatus vtkPlusWinProbeVideoSource::SetFocalPointDepth(int index, float depth
     ::SetFocalPointDepth(index, depth);
     SetPendingRecreateTables(true);
     //what we requested might be only approximately satisfied
-    m_TimeGainCompensation[index] = ::GetFocalPointDepth(index);
+    m_FocalPointDepth[index] = ::GetFocalPointDepth(index);
   }
   return PLUS_SUCCESS;
 }

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -201,8 +201,8 @@ protected:
   bool m_SpatialCompoundEnabled = false;
   float m_SpatialCompoundAngle = 10.0f;
   int32_t m_SpatialCompoundCount = 0;
-  std::vector<vtkPlusDataSource*> m_BSources;
-  std::vector<vtkPlusDataSource*> m_RFSources;
+  std::vector<vtkPlusDataSource*> m_PrimarySources;
+  std::vector<vtkPlusDataSource*> m_ExtraSources;
 
   enum Mode m_Mode = Mode::B;
 

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -148,8 +148,8 @@ public:
     return m_Mode;
   }
 
-  enum Mode StringToMode(std::string modeString);
-  std::string ModeToString(enum Mode mode);
+  Mode StringToMode(std::string modeString);
+  std::string ModeToString(Mode mode);
 
 protected:
   /*! Constructor */
@@ -204,7 +204,7 @@ protected:
   std::vector<vtkPlusDataSource*> m_PrimarySources;
   std::vector<vtkPlusDataSource*> m_ExtraSources;
 
-  enum Mode m_Mode = Mode::B;
+  Mode m_Mode = Mode::B;
 
 public:
   vtkPlusWinProbeVideoSource(const vtkPlusWinProbeVideoSource&) = delete;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -57,6 +57,12 @@ public:
   /* Get the scan depth of US probe (mm) */
   float GetScanDepthMm();
 
+   /* Set the scan depth of US probe (mm) */
+  PlusStatus SetSSDecimation(uint8_t value);
+
+  /* Get the scan depth of US probe (mm) */
+  uint8_t GetSSDecimation();
+
   /* Get the width of current transducer (mm) */
   float GetTransducerWidthMm();
 
@@ -80,6 +86,12 @@ public:
 
   /* Whether or not to use device's built-in frame reconstruction */
   bool GetUseDeviceFrameReconstruction() { return m_UseDeviceFrameReconstruction; }
+
+  /* Whether or not to use device's built-in frame reconstruction */
+  void SetUseDefaultDecimation(bool value) { m_UseDefaultDecimation = value; }
+
+  /* Whether or not to use device's built-in frame reconstruction */
+  bool GetUseDefaultDecimation() { return m_UseDefaultDecimation; }
 
   /*! Set ON/OFF of collecting US data. */
   PlusStatus FreezeDevice(bool freeze);
@@ -237,6 +249,8 @@ protected:
   int32_t m_MWidth = 256;
   int32_t m_MAcousticLineCount = 0;
   int32_t m_MDepth = 0;
+  uint8_t m_SSDecimation= 2;
+  bool m_UseDefaultDecimation = true;
   std::vector<vtkPlusDataSource*> m_PrimarySources;
   std::vector<vtkPlusDataSource*> m_ExtraSources;
 

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -201,7 +201,7 @@ protected:
   void AdjustBufferSize();
 
   friend int __stdcall frameCallback(int length, char* data, char* hHeader, char* hGeometry);
-  void ReconstructFrame(char* data);
+  void ReconstructFrame(char* data, std::vector<uint8_t>& buffer);
   void FlipTexture(char * data);
   void FrameCallback(int length, char* data, char* hHeader, char* hGeometry);
 
@@ -211,10 +211,12 @@ protected:
   uint8_t m_Voltage = 40;
   std::string m_TransducerID; //GUID
   double m_ADCfrequency = 60.0e6; //MHz
-  double m_TimestampOffset = 0; //difference between program start time and latest InternalStartRecording()
+  double m_TimestampOffset = 0; //difference between program start time and latest internal timer restart
+  double m_LastTimestamp = 0.0; //used to determine timer restarts and to update timestamp offset
   unsigned m_LineCount = 128;
   unsigned m_SamplesPerLine = 512;
-  std::vector<uint8_t> m_BModeBuffer; //avoid reallocating buffer every frame
+  std::vector<uint8_t> m_PrimaryBuffer;
+  std::vector<uint8_t> m_ExtraBuffer;
   bool m_UseDeviceFrameReconstruction = true;
   igsioTrackedFrame::FieldMapType m_CustomFields;
   double m_TimeGainCompensation[8];

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -141,6 +141,9 @@ public:
   void SetMWidth(int value);
   int GetMWidth();
 
+  void SetMWidthLines(int32_t value);
+  int32_t GetMWidthLines();
+
   void SetMAcousticLineCount(int32_t value);
   int32_t GetMAcousticLineCount();
 

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -203,7 +203,7 @@ protected:
   /*! Updates buffer size based on current depth */
   void AdjustBufferSizes();
 
-  friend int __stdcall frameCallback(int length, char* data, char* hHeader, char* hGeometry);
+  friend int __stdcall frameCallback(int length, char* data, char* hHeader, char* hGeometry, char* hModeFrameHeader);
   void ReconstructFrame(char* data, std::vector<uint8_t>& buffer, const FrameSizeType& frameSize);
   void FlipTexture(char* data, const FrameSizeType& frameSize);
   void FrameCallback(int length, char* data, char* hHeader, char* hGeometry);

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -132,7 +132,7 @@ public:
     BRF, // RF mode with reference B mode
     RF, // RF mode only
     M, // M mode
-    PW, // Pulsed Wave
+    PW, // Pulsed Wave Doppler
     CFD // Color-Flow Doppler
   };
 

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -202,6 +202,7 @@ protected:
 
   friend int __stdcall frameCallback(int length, char* data, char* hHeader, char* hGeometry);
   void ReconstructFrame(char* data);
+  void FlipTexture(char * data);
   void FrameCallback(int length, char* data, char* hHeader, char* hGeometry);
 
   float m_ScanDepth = 26.0; //mm

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -126,6 +126,31 @@ public:
   void SetSpatialCompoundCount(int32_t value);
   int32_t GetSpatialCompoundCount();
 
+  enum class Mode
+  {
+    B = 0, // only B mode
+    BRF, // RF mode with reference B mode
+    RF, // RF mode only
+    M, // M mode
+    PW, // Pulsed Wave
+    CFD // Color-Flow Doppler
+  };
+
+  /*! Sets the ultrasound imaging mode. */
+  void SetMode(Mode mode)
+  {
+    m_Mode = mode;
+  }
+
+  /*! Gets the ultrasound imaging mode. */
+  Mode GetMode()
+  {
+    return m_Mode;
+  }
+
+  enum Mode StringToMode(std::string modeString);
+  std::string ModeToString(enum Mode mode);
+
 protected:
   /*! Constructor */
   vtkPlusWinProbeVideoSource();
@@ -178,6 +203,8 @@ protected:
   int32_t m_SpatialCompoundCount = 0;
   std::vector<vtkPlusDataSource*> m_BSources;
   std::vector<vtkPlusDataSource*> m_RFSources;
+
+  enum Mode m_Mode = Mode::B;
 
 public:
   vtkPlusWinProbeVideoSource(const vtkPlusWinProbeVideoSource&) = delete;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -198,11 +198,11 @@ protected:
   void AdjustSpacing();
 
   /*! Updates buffer size based on current depth */
-  void AdjustBufferSize();
+  void AdjustBufferSizes();
 
   friend int __stdcall frameCallback(int length, char* data, char* hHeader, char* hGeometry);
-  void ReconstructFrame(char* data, std::vector<uint8_t>& buffer);
-  void FlipTexture(char * data);
+  void ReconstructFrame(char* data, std::vector<uint8_t>& buffer, const FrameSizeType& frameSize);
+  void FlipTexture(char* data, const FrameSizeType& frameSize);
   void FrameCallback(int length, char* data, char* hHeader, char* hGeometry);
 
   float m_ScanDepth = 26.0; //mm
@@ -214,7 +214,7 @@ protected:
   double m_TimestampOffset = 0; //difference between program start time and latest internal timer restart
   double m_LastTimestamp = 0.0; //used to determine timer restarts and to update timestamp offset
   unsigned m_LineCount = 128;
-  unsigned m_SamplesPerLine = 512;
+  unsigned m_SamplesPerLine = 0;
   std::vector<uint8_t> m_PrimaryBuffer;
   std::vector<uint8_t> m_ExtraBuffer;
   bool m_UseDeviceFrameReconstruction = true;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -126,6 +126,27 @@ public:
   void SetSpatialCompoundCount(int32_t value);
   int32_t GetSpatialCompoundCount();
 
+  void SetMModeEnabled(bool value);
+  bool GetMModeEnabled();
+
+  void SetMRevolvingEnabled(bool value);
+  bool GetMRevolvingEnabled();
+
+  void SetMPRFrequency(int32_t value);
+  int32_t GetMPRFrequency();
+
+  void SetMLineIndex(int32_t value);
+  int32_t GetMLineIndex();
+
+  void SetMWidth(int value);
+  int GetMWidth();
+
+  void SetMAcousticLineCount(int32_t value);
+  int32_t GetMAcousticLineCount();
+
+  void SetMDepth(int32_t value);
+  int32_t GetMDepth();
+
   enum class Mode
   {
     B = 0, // only B mode
@@ -150,6 +171,9 @@ public:
 
   Mode StringToMode(std::string modeString);
   std::string ModeToString(Mode mode);
+
+  int32_t MWidthFromSeconds(int value);
+  int MSecondsFromWidth(int32_t value);
 
 protected:
   /*! Constructor */
@@ -201,6 +225,12 @@ protected:
   bool m_SpatialCompoundEnabled = false;
   float m_SpatialCompoundAngle = 10.0f;
   int32_t m_SpatialCompoundCount = 0;
+  bool m_MRevolvingEnabled = false;
+  int32_t m_MPRF = 100;
+  int32_t m_MLineIndex = 60;
+  int32_t m_MWidth = 256;
+  int32_t m_MAcousticLineCount = 0;
+  int32_t m_MDepth = 0;
   std::vector<vtkPlusDataSource*> m_PrimarySources;
   std::vector<vtkPlusDataSource*> m_ExtraSources;
 

--- a/src/PlusDataCollection/vtkPlusTimestampedCircularBuffer.cxx
+++ b/src/PlusDataCollection/vtkPlusTimestampedCircularBuffer.cxx
@@ -17,6 +17,7 @@ vtkStandardNewMacro(vtkPlusTimestampedCircularBuffer);
 //----------------------------------------------------------------------------
 vtkPlusTimestampedCircularBuffer::vtkPlusTimestampedCircularBuffer()
   : Mutex(vtkIGSIORecursiveCriticalSection::New())
+  , NumberOfItems(0)
   , WritePointer(0)
   , CurrentTimeStamp(0.0)
   , LocalTimeOffsetSec(0.0)


### PR DESCRIPTION
Default is set to 2, as 1 results in tracebacks for 30-40mm scan depths.