### PR TITLE
Andor SDK version checking updates

### DIFF
--- a/src/PlusDataCollection/Andor/vtkPlusAndorCamera.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorCamera.cxx
@@ -130,7 +130,7 @@ std::string vtkPlusAndorCamera::GetSdkVersion()
   }
   else
   {
-    versionString << "Andor SDK version: "  << sParam << std::endl;
+    versionString << "Andor SDK version: "  << sParam << std::ends;
   }
 
   return versionString.str();

--- a/src/PlusDataCollection/Andor/vtkPlusAndorCamera.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorCamera.cxx
@@ -144,16 +144,6 @@ vtkPlusAndorCamera::vtkPlusAndorCamera()
 
   this->StartThreadForInternalUpdates = true; // should frames be acquired automatically?
   this->AcquisitionRate = 1.0; // this controls the frequency
-
-  unsigned result = Initialize("");
-  if(result != DRV_SUCCESS)
-  {
-    LOG_ERROR("Andor SDK could not be initialized");
-  }
-  else
-  {
-    LOG_DEBUG("Andor SDK initialized.");
-  }
 }
 
 // ----------------------------------------------------------------------------
@@ -168,6 +158,16 @@ vtkPlusAndorCamera::~vtkPlusAndorCamera()
 // ----------------------------------------------------------------------------
 PlusStatus vtkPlusAndorCamera::InitializeAndorCamera()
 {
+  unsigned initializeResult = Initialize("");
+  if(initializeResult != DRV_SUCCESS)
+  {
+    LOG_ERROR("Andor SDK could not be initialized");
+  }
+  else
+  {
+    LOG_DEBUG("Andor SDK initialized.");
+  }
+
   // Check the safe temperature, and the maximum allowable temperature on the camera.
   // Use the min of the two as the safe temp.
   int MinTemp, MaxTemp;

--- a/src/PlusDataCollection/Andor/vtkPlusAndorCamera.cxx
+++ b/src/PlusDataCollection/Andor/vtkPlusAndorCamera.cxx
@@ -122,16 +122,17 @@ std::string vtkPlusAndorCamera::GetSdkVersion()
 {
   std::ostringstream versionString;
 
-  unsigned epromVer;
-  unsigned cofVer;
-  unsigned driverRev;
-  unsigned driverVer;
-  unsigned dllRev;
-  unsigned dllVer;
+  char sParam[256];
+  unsigned result = GetVersionInfo(AT_SDKVersion, sParam, sizeof(sParam));
+  if(result != DRV_SUCCESS)
+  {
+    LOG_ERROR("Andor SDK version could not be retrieved.");
+  }
+  else
+  {
+    versionString << "Andor SDK version: "  << sParam << std::endl;
+  }
 
-  unsigned andorResult = GetSoftwareVersion(&epromVer, &cofVer, &driverRev, &driverVer, &dllRev, &dllVer);
-
-  versionString << "Andor SDK version: "  << dllVer << "." << dllRev << std::endl;
   return versionString.str();
 }
 


### PR DESCRIPTION
@dzenanz PlusVersion.exe can now report the SDK version without the device being plugged in because it doesn't need to initialize the SDK successfully.
```
> ./PlusVersion.exe
System start timestamp: 366672
Software version: Plus-2.9.0.b1eabea7 - Win64
Supported devices:
  - AndorCamera (ver: Andor SDK version: 2.102.30001.0
)
```

![image](https://user-images.githubusercontent.com/15837524/95920014-a331fc80-0d7c-11eb-83f0-38758aa85b8c.png)
